### PR TITLE
Feature: Custom Knowledge Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ Streamlit web app providing a Large Language Model (LLM) chatbot with a custom k
 
 - Deployed to Streamlit Community Cloud ☁️
 - Conversation LLM chatbot chain only
-- For ease of use and privacy, the semantic search of personal or organizational documents to create a custom knowledge base for the LLM will be available only as a local deployment feature
+- For simplicity and privacy, the semantic search of personal or organizational documents to create a custom knowledge base for the LLM is available only as a local deployment feature
+
+## Custom Knowledge Base
+
+- Include the data you wish to upload for a custom knowledge base for the LLM in the 'data' directory
+- Anticipates to load any .txt, .pdf, .csv, .docx, or .xlsx files found in the directory
+- Data is persisted within a local ChromaDB vector store
+- Future work includes web scraping
 
 ## Project Details
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Streamlit web app providing a Large Language Model (LLM) chatbot with a custom k
 
 ## Custom Knowledge Base
 
-- Include the data you wish to upload for a custom knowledge base for the LLM in the 'data' directory
+- Extend the LLM chatbot with a custom knowledge base
+- Include the data you wish to upload to extend the LLM chatbot in the 'data' directory
 - Anticipates to load any .txt, .pdf, .csv, .docx, or .xlsx files found in the directory
 - Data is persisted within a local ChromaDB vector store
 - Future work includes web scraping
@@ -35,7 +36,7 @@ Streamlit web app providing a Large Language Model (LLM) chatbot with a custom k
 
 ## Getting Started
 
-- Create a .streamlit folder in the 'src' directory and include the contents of the [.streamlit.example](src/.streamlit.example)
+- Create a .streamlit folder in the 'src' directory and include the contents of the [.streamlit.example](.streamlit.example)
 
 - To initialize a virtual enviroment, navigate to the 'src' directory in the terminal and execute
 
@@ -54,6 +55,7 @@ Streamlit web app providing a Large Language Model (LLM) chatbot with a custom k
   ```
   $ pip install -r requirements.txt
   ```
+  Some LangChain packages may have hidden dependencies that require pip installation
 
 - Run the app
 

--- a/app.py
+++ b/app.py
@@ -2,11 +2,26 @@
 from dataclasses import dataclass
 from langchain.chat_models import ChatOpenAI
 from langchain.callbacks import get_openai_callback
-from langchain.chains import ConversationChain
 from langchain.chains.conversation.memory import ConversationSummaryMemory
+from langchain.document_loaders import DirectoryLoader
+from langchain.document_loaders import Docx2txtLoader
+from langchain.document_loaders import PyPDFLoader
+from langchain.document_loaders import TextLoader
+from langchain.document_loaders import UnstructuredExcelLoader
+from langchain.document_loaders.csv_loader import CSVLoader
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+from langchain.chains import ConversationalRetrievalChain
 from typing import Literal
+import os 
+import shutil
 import streamlit as st
+import threading
 
+
+# Get the API key for the LLM (If required, currently using OpenAI for chatbot)
+os.environ["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
 
 # Set page configuration
 st.set_page_config(page_title="Ask Chatbot")
@@ -21,6 +36,101 @@ class Message:
   message: str
 
 
+def load_directory_documents(path_to_data):
+  """
+  Loads & extracts text data within a local directory for a custom knowledge base. 
+  Accepts the path_to_data.
+  Anticipates to load any .txt, .pdf, .csv, .docx, or .xlsx files in the directory. 
+  Many loader classes available, see docs: https://python.langchain.com/docs/integrations/document_loaders
+  Retuns the text documents.
+  """
+  # Define loaders
+  pdf_loader = DirectoryLoader(path_to_data, glob="./*.pdf", loader_cls=PyPDFLoader, use_multithreading=True)
+  txt_loader = DirectoryLoader(path_to_data, glob="./*.txt", loader_cls=TextLoader)
+  csv_loader = DirectoryLoader(path_to_data, glob="./*.csv", loader_cls=CSVLoader)
+  word_loader = DirectoryLoader(path_to_data, glob="./*.docx", loader_cls=Docx2txtLoader)
+  excel_loader = DirectoryLoader(path_to_data, glob="./*.xlsx", loader_cls=UnstructuredExcelLoader)
+  
+  loaders = [pdf_loader, txt_loader, csv_loader, word_loader, excel_loader]
+  documents = []
+  for loader in loaders:
+    documents.extend(loader.load())
+  
+  if len(documents) == 0: 
+    # Terminate the app if no data found
+    st.write(f"No data found within: {path_to_data}")
+    st.stop()
+  
+  # Display results
+  filenames = []
+  filenames.append("Uploaded Documents:")
+  for doc in documents:
+    filename = doc.metadata.get('source')
+    # There will be multiple .csv docs per uploaded .csv
+    if filename not in filenames:
+      filenames.append(filename)
+  # Remove text before the last '/' character
+  cleaned_filenames = [filename.split('/')[-1] for filename in filenames]
+  # Combine the filenames into a single string for the HTML
+  filenames_combined = "<br>".join(cleaned_filenames)
+  div = f"""
+        <div class="chat-row">
+          <div class="chat-bubble human-bubble">&#8203;{filenames_combined}</div>
+        </div>
+        """
+  st.markdown(div, unsafe_allow_html=True)
+    
+  return documents
+
+
+def get_chunks(documents):
+  """
+  Chunks the documents for vector embedding.
+  Accepts a list of documents & returns the split text.
+  """
+  # Chunk data for embedding
+  text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+  texts = text_splitter.split_documents(documents)
+  
+  return texts
+  
+
+def embed_and_persist_vectors(texts, persist_dir):
+  """
+  Performs vector embeddings and persists the Chorma vector store to disk.
+  Accepts the split texts & a path to store the vectors.
+  Returns the persist_directory that was used.
+  Note: Different embedding models will output different vector dimensionalities,
+  require different resources, and have different performance characteristics.
+  Ensure vector compatibility with the LLM chatbot.
+  """
+  # Create a Chroma vector store 
+  vector_store = Chroma.from_documents(
+    documents=texts, 
+    embedding=OpenAIEmbeddings(),
+    persist_directory=persist_dir
+    )
+
+  # Persist the vector store to disk
+  vector_store.persist()
+  vector_store = None
+  
+  return persist_dir
+
+
+def create_vector_store(persist_dir):
+  """
+  Loads & returns the Chroma vector store persisted on disk. 
+  Accepts the path where the vectors were stored & returns the vector store.
+  Note: If the knowledge base is unchanged, embedding & persisting the data first can be skipped.
+  Useful when embedding large amounts of data.
+  """
+  # Loads the vector store persisted to disk
+  vector_store = Chroma(persist_directory=persist_dir, embedding_function=OpenAIEmbeddings())
+  
+  return vector_store
+
+
 def load_css():
   """
   Gets page styles
@@ -28,7 +138,7 @@ def load_css():
   with open("./static/styles.css", "r") as f:
     css = f"<style>{f.read()}</style>"
     st.markdown(css, unsafe_allow_html=True)
-
+  
 
 def initialize_session_state():
   """
@@ -36,27 +146,69 @@ def initialize_session_state():
   """
   # Define chat history 
   if "history" not in st.session_state:
-      st.session_state.history = []
+    st.session_state.history = []
     
   # Define a token count 
   if "token_count" not in st.session_state:
-      st.session_state.token_count = 0
+    st.session_state.token_count = 0
     
   # Define a conversation chain 
   if "conversation" not in st.session_state:
-    # Large Lanuage Model (LLM) for the chatbot
+    
+    # Path to the data to process 
+    path_to_data = "./data/"
+    # Name for the local vector store
+    db_name = "demo"
+    # Path to persist the vector store
+    persist_dir = f"chroma-db_{db_name}"
+    # Option to load data or skip
+    load_data = True
+    # Remove existing persist directory
+    remove_existing_perist_directory = True
+
+    if not os.path.exists(persist_dir): 
+      os.makedirs(persist_dir)
+    
+    # Thread lock for data processing
+    data_loading_lock = threading.Lock()
+      
+    if load_data:
+      with data_loading_lock:
+        
+        if os.path.exists(persist_dir) & remove_existing_perist_directory:
+          # Delete directory for a fresh store
+          absolute_path = os.path.abspath(persist_dir)
+          shutil.rmtree(absolute_path)
+        
+        # Loads text from the documents
+        documents = load_directory_documents(path_to_data)
+    
+        # Splits data for vector embedding
+        texts = get_chunks(documents)
+    
+        # Performs vector embedding and persists results
+        persist_dir = embed_and_persist_vectors(texts, persist_dir)
+    
+    # Create a vector store for the knowledge base to query
+    vector_store = create_vector_store(persist_dir)
+    
+    # Define the Large Lanuage Model (LLM) for the chatbot
     llm = ChatOpenAI(
       temperature=0,
       openai_api_key=st.secrets["OPENAI_API_KEY"],
       model_name="gpt-3.5-turbo"
     )
-    # The conversation chain
-    st.session_state.conversation = ConversationChain(
+    
+    # Define the conversational retrieval chain
+    st.session_state.conversation = ConversationalRetrievalChain.from_llm(
       llm=llm,
-      memory=ConversationSummaryMemory(llm=llm),
+      # Define a retreiver for the custom knowledge base
+      retriever=vector_store.as_retriever(search_kwargs={"k": 3}),
+      # Create a Memory object 
+      memory = ConversationSummaryMemory(llm=llm, memory_key="chat_history", return_messages=True)
     )
+      
         
-
 def on_click_callback():
   """
   Manages chat history in session state
@@ -67,11 +219,11 @@ def on_click_callback():
     human_prompt = st.session_state.human_prompt
     
     # Call the conversation chain defined in session state on user prompt
-    llm_response = st.session_state.conversation.run(human_prompt)
+    llm_response = st.session_state.conversation({"question": human_prompt})
     
     # Persist the prompt and llm_response in session state
     st.session_state.history.append(Message("human", human_prompt))
-    st.session_state.history.append(Message("AI", llm_response))
+    st.session_state.history.append(Message("AI", llm_response['answer']))
     
     # Pesist token count in session state
     st.session_state.token_count += callback.total_tokens
@@ -81,7 +233,6 @@ def on_click_callback():
 
 
 def main():
-  
   load_css()
   initialize_session_state()
   
@@ -96,7 +247,6 @@ def main():
   # Create a empty placeholder for the token count
   token_placeholder = st.empty()
 
-
   # Display chat history within chat_placehoder
   with chat_placeholder:
     for chat in st.session_state.history:
@@ -110,7 +260,6 @@ def main():
     
     for _ in range(3):
       st.markdown("")
-    
     
   # Create the user prompt within prompt_placeholder
   with prompt_placeholder:
@@ -128,13 +277,14 @@ def main():
       on_click=on_click_callback, 
     )
 
-  
   # Display # of tokens used & conversation context within token_placeholder
-  token_placeholder.caption(f"""
-  Used {st.session_state.token_count} tokens \n
-  Debug LangChain conversation: 
-  {st.session_state.conversation.memory.buffer}
-  """)
+  token_placeholder.caption(
+    f"""
+    Used {st.session_state.token_count} tokens \n
+    Debug LangChain conversation: 
+    {st.session_state.conversation.memory.buffer}
+    """
+    )
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -133,7 +133,7 @@ def create_vector_store(persist_dir):
 
 def load_css():
   """
-  Gets page styles
+  Retrieves page styles
   """
   with open("./static/styles.css", "r") as f:
     css = f"<style>{f.read()}</style>"
@@ -159,15 +159,12 @@ def initialize_session_state():
     path_to_data = "./data/"
     # Name for the local vector store
     db_name = "demo"
-    # Path to persist the vector store
+    # Directory to persist the vector store
     persist_dir = f"chroma-db_{db_name}"
-    # Option to load data or skip
+    # Load or skip data upload
     load_data = True
-    # Remove existing persist directory
+    # Remove existing vector store
     remove_existing_perist_directory = True
-
-    if not os.path.exists(persist_dir): 
-      os.makedirs(persist_dir)
     
     # Thread lock for data processing
     data_loading_lock = threading.Lock()
@@ -176,9 +173,12 @@ def initialize_session_state():
       with data_loading_lock:
         
         if os.path.exists(persist_dir) & remove_existing_perist_directory:
-          # Delete directory for a fresh store
+          # Delete files & subdirectories within the directory
           absolute_path = os.path.abspath(persist_dir)
           shutil.rmtree(absolute_path)
+        
+        if not os.path.exists(persist_dir): 
+          os.makedirs(persist_dir)
         
         # Loads text from the documents
         documents = load_directory_documents(path_to_data)
@@ -189,7 +189,7 @@ def initialize_session_state():
         # Performs vector embedding and persists results
         persist_dir = embed_and_persist_vectors(texts, persist_dir)
     
-    # Create a vector store for the knowledge base to query
+    # Create a vector store to serve the custom knowledge base
     vector_store = create_vector_store(persist_dir)
     
     # Define the Large Lanuage Model (LLM) for the chatbot
@@ -202,7 +202,7 @@ def initialize_session_state():
     # Define the conversational retrieval chain
     st.session_state.conversation = ConversationalRetrievalChain.from_llm(
       llm=llm,
-      # Define a retreiver for the custom knowledge base
+      # Define a retreiver for the knowledge base context
       retriever=vector_store.as_retriever(search_kwargs={"k": 3}),
       # Create a Memory object 
       memory = ConversationSummaryMemory(llm=llm, memory_key="chat_history", return_messages=True)

--- a/data/copy-paste-data.txt
+++ b/data/copy-paste-data.txt
@@ -1,0 +1,1 @@
+Copy & paste your data for the LLM here


### PR DESCRIPTION
Implemented functionality to extend the LLM chatbot with a custom knowledge base. This includes the ability to upload a variety of file types within the 'data' directory simultaneously, extract the text, chunk the documents for vector embedding, then embed and persist these vectors within a local ChromaDB vector store. Added a conversational retrieval chain for the LLM chatbot. A quick way to assess this functionality is to ask the LLM to provide answers from data it could not have previously been trained on. 

_Uploaded Documents Preview_
![uploaded-documents-displayed](https://github.com/c-grigsby/ask-chatbot/assets/77213293/8eba222e-a311-466f-b684-9ba9c215be3f)

_Query the Knowledge Base_
![chatbot-custom-knowledge-base](https://github.com/c-grigsby/ask-chatbot/assets/77213293/7fb2e7b3-92ad-423a-9d8e-0ca63e7dd341)

![custom-knowledge-base](https://github.com/c-grigsby/ask-chatbot/assets/77213293/d4868bdd-066c-453a-8690-c99ade0b0f8d)